### PR TITLE
regex scan returns a cell instead of numeric that is needed for indexing.

### DIFF
--- a/foldersync.m
+++ b/foldersync.m
@@ -371,6 +371,12 @@ for ii = 1 : length(items)
                 [m1, m2] = regexp(fl2_temp(i).name, setup.mousefolder);
 
                 if ~isempty(m1)
+                    % If regex returns a cell even though the output is a
+                    % single lement get convert the values to a numberic
+                    if length(m1) == 1
+                        m1 = cell2mat(m1);
+                        m2 = cell2mat(m2);
+                    end
                     fl2_temp(i).mouse = fl2_temp(i).name(m1:m2);
                 else
                     fl2_temp(i).mouse = 'unknown';


### PR DESCRIPTION
Now forces regex output to be numeric if it returns only one mouse name. Not it works with a single user/mouse name but it may still fail with multiple mouse names. This regex behavior could be version specific. I tested it on R2019a.